### PR TITLE
Changes default care for new sleeves from Max to the player set default for colonists

### DIFF
--- a/1.6/Source/AlteredCarbon/AC_Utils.cs
+++ b/1.6/Source/AlteredCarbon/AC_Utils.cs
@@ -892,7 +892,7 @@ namespace AlteredCarbon
             pawn.guest.recruitable = true;
             pawn.Name = new NameSingle("AC.EmptySleeve".Translate());
             pawn.story.title = null;
-            pawn.playerSettings.medCare = MedicalCareCategory.Best;
+            pawn.playerSettings.medCare = Find.PlaySettings.defaultCareForColonist;
             pawn.workSettings.EnableAndInitialize();
             pawn.skills.Notify_SkillDisablesChanged();
             pawn.story.Childhood = AC_DefOf.AC_VatGrownChild;


### PR DESCRIPTION
I was having trouble with my Glitterworld medicine being wasted on new sleeves. This change makes their medicine/care level be set to the player set default for all new colonists.