### PR TITLE
Fix NullReferenceException in Dreamcatcher TryGainMemory postfix

### DIFF
--- a/1.5/Source/AlteredCarbon/HarmonyPatches/MemoryThoughtHandler_TryGainMemory_Patch.cs
+++ b/1.5/Source/AlteredCarbon/HarmonyPatches/MemoryThoughtHandler_TryGainMemory_Patch.cs
@@ -9,7 +9,7 @@ public static class MemoryThoughtHandler_TryGainMemory_Patch
 {
     public static void Postfix(MemoryThoughtHandler __instance, ref Thought_Memory newThought)
     {
-        if (__instance?.pawn?.health.hediffSet.HasHediff(AC_DefOf.AC_Dreamcatcher) != true || newThought == null) return;
+        if (__instance?.pawn?.health.hediffSet.HasHediff(AC_DefOf.AC_Dreamcatcher) != true || newThought?.pawn == null) return;
         if (newThought.MoodOffset() < 0)
         {
             newThought.durationTicksOverride = (int)(newThought.DurationTicks * 0.75f);

--- a/1.6/Source/AlteredCarbon/HarmonyPatches/MemoryThoughtHandler_TryGainMemory_Patch.cs
+++ b/1.6/Source/AlteredCarbon/HarmonyPatches/MemoryThoughtHandler_TryGainMemory_Patch.cs
@@ -9,7 +9,7 @@ public static class MemoryThoughtHandler_TryGainMemory_Patch
 {
     public static void Postfix(MemoryThoughtHandler __instance, ref Thought_Memory newThought)
     {
-        if (__instance?.pawn?.health.hediffSet.HasHediff(AC_DefOf.AC_Dreamcatcher) != true || newThought == null) return;
+        if (__instance?.pawn?.health.hediffSet.HasHediff(AC_DefOf.AC_Dreamcatcher) != true || newThought?.pawn == null) return;
         if (newThought.MoodOffset() < 0)
         {
             newThought.durationTicksOverride = (int)(newThought.DurationTicks * 0.75f);


### PR DESCRIPTION
## Summary
- The Harmony postfix on `MemoryThoughtHandler.TryGainMemory` calls `newThought.MoodOffset()`, but when the vanilla method exits early (before `newThought.pawn` is assigned), this causes a NullReferenceException
- This happens every tick interval for any pawn whose genes or hediffs cause `CanGetThought` to return false for a given thought (e.g. a pawn with the DarkVision gene being given the EnvironmentDark thought)
- Fix: change `newThought == null` to `newThought?.pawn == null`, which also covers the uninitialized-pawn case

## Test plan
- Load a save with a pawn that has both the Dreamcatcher hediff and the DarkVision gene (or any nullifying gene/hediff)
- Place the pawn in darkness and verify no NullReferenceException spam in the log