### PR TITLE
Fix Dreamcatcher giving SleepDisturbed instead of PleasantDream on wake

### DIFF
--- a/1.5/Source/AlteredCarbon/AC_DefOf.cs
+++ b/1.5/Source/AlteredCarbon/AC_DefOf.cs
@@ -116,6 +116,7 @@ namespace AlteredCarbon
         public static HediffDef AC_VoiceSynthesizer;
         public static HediffDef AC_MentalFuse;
         public static HediffDef AC_Dreamcatcher;
+        public static ThoughtDef AC_PleasantDream;
         public static ThingCategoryDef WeaponsMelee;
         [DefAlias("AC_RemoteStack")] public static HediffDef AC_RemoteStackHediff;
         public static ThingDef AC_RemoteStack;

--- a/1.5/Source/AlteredCarbon/HarmonyPatches/RestUtility_WakeUp_Patch.cs
+++ b/1.5/Source/AlteredCarbon/HarmonyPatches/RestUtility_WakeUp_Patch.cs
@@ -11,7 +11,7 @@ public static class RestUtility_WakeUp_Patch
     {
         if (p.health.hediffSet.HasHediff(AC_DefOf.AC_Dreamcatcher))
         {
-            p.needs.mood.thoughts.memories.TryGainMemory(ThoughtDefOf.SleepDisturbed, null, null);
+            p.needs.mood.thoughts.memories.TryGainMemory(AC_DefOf.AC_PleasantDream, null, null);
         }
     }
 }

--- a/1.6/Source/AlteredCarbon/AC_DefOf.cs
+++ b/1.6/Source/AlteredCarbon/AC_DefOf.cs
@@ -115,6 +115,7 @@ namespace AlteredCarbon
         public static HediffDef AC_VoiceSynthesizer;
         public static HediffDef AC_MentalFuse;
         public static HediffDef AC_Dreamcatcher;
+        public static ThoughtDef AC_PleasantDream;
         public static ThingCategoryDef WeaponsMelee;
         [DefAlias("AC_RemoteStack")] public static HediffDef AC_RemoteStackHediff;
         public static ThingDef AC_RemoteStack;

--- a/1.6/Source/AlteredCarbon/HarmonyPatches/RestUtility_WakeUp_Patch.cs
+++ b/1.6/Source/AlteredCarbon/HarmonyPatches/RestUtility_WakeUp_Patch.cs
@@ -11,7 +11,7 @@ public static class RestUtility_WakeUp_Patch
     {
         if (p.health.hediffSet.HasHediff(AC_DefOf.AC_Dreamcatcher))
         {
-            p.needs.mood.thoughts.memories.TryGainMemory(ThoughtDefOf.SleepDisturbed, null, null);
+            p.needs.mood.thoughts.memories.TryGainMemory(AC_DefOf.AC_PleasantDream, null, null);
         }
     }
 }


### PR DESCRIPTION
## Summary
- `RestUtility_WakeUp_Patch` grants `ThoughtDefOf.SleepDisturbed` (a negative mood thought) to pawns with the Dreamcatcher hediff on waking — the opposite of what the feature intends
- Replace with `AC_DefOf.AC_PleasantDream`, which is the positive thought already defined in `Thoughts_Situation_Misc.xml` for this purpose
- Add `AC_PleasantDream` to `AC_DefOf` so it's resolved by the DefOf system
- Fixed in both 1.5 and 1.6

Fixes #6